### PR TITLE
sepolicy: Allow Settings > Device info to load selinux status

### DIFF
--- a/prebuilts/api/31.0/private/system_app.te
+++ b/prebuilts/api/31.0/private/system_app.te
@@ -173,6 +173,9 @@ get_prop(system_app, oem_unlock_prop)
 # Allow system apps to act as Perfetto producers.
 perfetto_producer(system_app)
 
+#selinux status
+allow system_app selinuxfs:file r_file_perms;
+
 ###
 ### Neverallow rules
 ###

--- a/private/system_app.te
+++ b/private/system_app.te
@@ -173,6 +173,9 @@ get_prop(system_app, oem_unlock_prop)
 # Allow system apps to act as Perfetto producers.
 perfetto_producer(system_app)
 
+#selinux status
+allow system_app selinuxfs:file r_file_perms;
+
 ###
 ### Neverallow rules
 ###


### PR DESCRIPTION
Otherwise it will show permissive even if selinux is Enforcing